### PR TITLE
Fix the query during rollback operation - change @ operator to upper

### DIFF
--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -562,15 +562,11 @@ async function batchDeleteAndThenUpdate(
                 limit: batchSize,
                 hooks: false,
                 where: {
-                  [Op.and]: [
-                    {
-                      __block_range: {
-                        [Op.contains]: targetBlockUnit,
-                      },
-                    },
-                    sequelize.where(sequelize.fn('upper', sequelize.col('_block_range')), Op.not, null),
-                  ],
-                },
+                [Op.and]: [
+                  sequelize.where(sequelize.fn('upper', sequelize.col('_block_range')), Op.gt, targetBlockUnit),
+                  sequelize.where(sequelize.fn('upper', sequelize.col('_block_range')), Op.not, null),
+                ],
+              },
               }
             ),
       ]);

--- a/packages/node/src/utils/substrate.ts
+++ b/packages/node/src/utils/substrate.ts
@@ -385,7 +385,7 @@ export async function fetchEventsRange(
         try {
           const events = await api.query.system.events.at(hash);
           if (events && events.length > 0) {
-            console.log(`[DEBUG] Block ${blockNumber}: Found ${events.length} events using standard query`);
+            // console.log(`[DEBUG] Block ${blockNumber}: Found ${events.length} events using standard query`);
             return events;
           }
         } catch (standardErr) {
@@ -403,7 +403,7 @@ export async function fetchEventsRange(
           const eventCount = totalEventCount && totalEventCount.toNumber ? totalEventCount.toNumber() : 0;
           
           if (eventCount > 0) {
-            console.log(`[DEBUG] Block ${blockNumber} has ${eventCount} events (using segmented approach)`);
+            // console.log(`[DEBUG] Block ${blockNumber} has ${eventCount} events (using segmented approach)`);
             
             // Calculate number of segments to check (EventSegmentSize = 100)
             const SEGMENT_SIZE = 100;


### PR DESCRIPTION
## Problem Summary

SubQuery fork detection was causing severe performance degradation on large databases, with rollback operations taking hours instead of seconds, leading to:
- 900+ seconds per block processing
- 0 blocks/s throughput
- Complete system stalls during fork detection

## Root Cause

The SubQuery rewind logic had a critical bug in the UPDATE operation that was querying ALL historical records instead of only recent ones.

### Broken Logic (Before)
```sql
WHERE _block_range @> 2876417 AND upper(_block_range) IS NOT NULL
```
This finds **ALL records that were active at the rewind point** - potentially millions of records in a BIG database.

### Fixed Logic (After)
```sql
WHERE upper(_block_range) > 2876417 AND upper(_block_range) IS NOT NULL
```
This finds **only records that were closed AFTER the rewind point** - typically thousands of records.

## Key Concepts Explained

### Understanding `_block_range`
The `_block_range` column is a PostgreSQL range type that tracks when each record was active:
- Format: `[start_block, end_block)` 
- Example: `[1000, 2000)` means active from block 1000 to 1999
- Open range: `[1000,)` means active from block 1000 onwards (current record)

### SQL Operators and Functions

**`@>` (Contains Operator)**
- Checks if a range contains a specific value
- `_block_range @> 2876417` finds ALL records where the range includes block 2876417
- Problem: This includes millions of historical records on large databases

**`upper(_block_range)`**
- Returns the upper bound of the range (when record was closed)
- `upper([1000, 2000))` returns 2000
- `upper([1000,))` returns NULL (still active)

**`lower(_block_range)`**
- Returns the lower bound of the range (when record was created)
- `lower([1000, 2000))` returns 1000

### Why Two Different Indexes?

SubQuery's rollback process has two phases:

1. **DELETE Phase**: Removes records created after rollback point
   - Uses: `WHERE lower(_block_range) > rollback_point`
   - Needs: Index on `lower(_block_range)`

2. **UPDATE Phase**: Reopens records closed after rollback point  
   - Uses: `WHERE upper(_block_range) > rollback_point`
   - Needs: Index on `upper(_block_range)`

Without BOTH indexes, PostgreSQL must scan the entire table (disaster on 1TB databases).
