### PR TITLE
Add Redis Support to SubQuery Indexer

### DIFF
--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -34,6 +34,7 @@
     "cross-fetch": "^3.1.6",
     "csv-stringify": "^6.5.1",
     "dayjs": "^1.11.12",
+    "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
     "lru-cache": "10.1.0",
     "merkle-tools": "^1.4.1",

--- a/packages/node-core/src/indexer/core.module.ts
+++ b/packages/node-core/src/indexer/core.module.ts
@@ -15,6 +15,7 @@ import {PoiService, PoiSyncService} from './poi';
 import {SandboxService} from './sandbox.service';
 import {StoreService} from './store.service';
 import {storeModelFactory} from './storeModelProvider';
+import {RedisService} from './redis.service';
 
 @Module({
   providers: [
@@ -28,6 +29,7 @@ import {storeModelFactory} from './storeModelProvider';
     PoiService,
     PoiSyncService,
     StoreService,
+    RedisService,
     {
       provide: 'IStoreModelProvider',
       useFactory: storeModelFactory,
@@ -46,6 +48,7 @@ import {storeModelFactory} from './storeModelProvider';
     StoreService,
     'IStoreModelProvider',
     InMemoryCacheService,
+    RedisService,
   ],
 })
 export class CoreModule {}

--- a/packages/node-core/src/indexer/index.ts
+++ b/packages/node-core/src/indexer/index.ts
@@ -26,3 +26,4 @@ export * from './unfinalizedBlocks.service';
 export * from './monitor.service';
 export * from './multiChainRewind.service';
 export * from './core.module';
+export * from './redis.service';

--- a/packages/node-core/src/indexer/redis.service.ts
+++ b/packages/node-core/src/indexer/redis.service.ts
@@ -1,0 +1,309 @@
+// Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {Injectable, OnModuleDestroy, OnModuleInit} from '@nestjs/common';
+import Redis, {RedisOptions} from 'ioredis';
+import {getLogger} from '../logger';
+import {NodeConfig} from '../configure';
+
+const logger = getLogger('redis-service');
+
+export interface SafeRedisClient {
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string, expiryMode?: string, time?: number) => Promise<string | null>;
+  del: (key: string) => Promise<number>;
+  exists: (key: string) => Promise<number>;
+  expire: (key: string, seconds: number) => Promise<number>;
+  ttl: (key: string) => Promise<number>;
+  incr: (key: string) => Promise<number>;
+  decr: (key: string) => Promise<number>;
+  incrby: (key: string, increment: number) => Promise<number>;
+  decrby: (key: string, decrement: number) => Promise<number>;
+  hget: (key: string, field: string) => Promise<string | null>;
+  hset: (key: string, field: string, value: string) => Promise<number>;
+  hdel: (key: string, field: string) => Promise<number>;
+  hgetall: (key: string) => Promise<Record<string, string>>;
+  hexists: (key: string, field: string) => Promise<number>;
+  hkeys: (key: string) => Promise<string[]>;
+  hvals: (key: string) => Promise<string[]>;
+  hlen: (key: string) => Promise<number>;
+  lpush: (key: string, ...values: string[]) => Promise<number>;
+  rpush: (key: string, ...values: string[]) => Promise<number>;
+  lpop: (key: string) => Promise<string | null>;
+  rpop: (key: string) => Promise<string | null>;
+  llen: (key: string) => Promise<number>;
+  lrange: (key: string, start: number, stop: number) => Promise<string[]>;
+  sadd: (key: string, ...members: string[]) => Promise<number>;
+  srem: (key: string, ...members: string[]) => Promise<number>;
+  sismember: (key: string, member: string) => Promise<number>;
+  smembers: (key: string) => Promise<string[]>;
+  scard: (key: string) => Promise<number>;
+  zadd: (key: string, score: number, member: string) => Promise<number>;
+  zrem: (key: string, member: string) => Promise<number>;
+  zscore: (key: string, member: string) => Promise<string | null>;
+  zrange: (key: string, start: number, stop: number) => Promise<string[]>;
+  zrevrange: (key: string, start: number, stop: number) => Promise<string[]>;
+  zcard: (key: string) => Promise<number>;
+}
+
+@Injectable()
+export class RedisService implements OnModuleInit, OnModuleDestroy {
+  private client?: Redis;
+  private isConnected = false;
+  private connectPromise?: Promise<void>;
+  private connectionAttempted = false;
+
+  constructor(private readonly nodeConfig: NodeConfig) {}
+
+  async onModuleInit(): Promise<void> {
+    // Initialize Redis connection during module initialization
+    await this.ensureConnected();
+  }
+
+  private async ensureConnected(): Promise<boolean> {
+    // If Redis is not configured, return false
+    if (!process.env.REDIS_HOST && !process.env.REDIS_ENDPOINT) {
+      if (!this.connectionAttempted) {
+        logger.info('Redis is not configured. Set REDIS_HOST or REDIS_ENDPOINT to enable Redis support.');
+        this.connectionAttempted = true;
+      }
+      return false;
+    }
+
+    if (this.isConnected) {
+      return true;
+    }
+
+    // If already connecting, wait for that to complete
+    if (this.connectPromise) {
+      try {
+        await this.connectPromise;
+        return this.isConnected;
+      } catch {
+        return false;
+      }
+    }
+
+    // Start new connection
+    this.connectPromise = this.connect();
+    try {
+      await this.connectPromise;
+      return this.isConnected;
+    } catch (error) {
+      logger.error('Failed to connect to Redis:', error);
+      return false;
+    }
+  }
+
+  private async connect(): Promise<void> {
+    try {
+      const redisOptions: RedisOptions = {
+        host: process.env.REDIS_HOST || 'localhost',
+        port: parseInt(process.env.REDIS_PORT || '6379'),
+        password: process.env.REDIS_PASSWORD,
+        db: parseInt(process.env.REDIS_DB || '0'),
+        retryStrategy: (times: number) => {
+          if (times > 3) {
+            logger.error('Redis connection failed after 3 attempts');
+            return null; // Stop retrying
+          }
+          const delay = Math.min(times * 50, 2000);
+          logger.warn(`Redis connection failed, retrying in ${delay}ms...`);
+          return delay;
+        },
+      };
+
+      // Support Redis connection string
+      if (process.env.REDIS_ENDPOINT) {
+        this.client = new Redis(process.env.REDIS_ENDPOINT);
+      } else {
+        this.client = new Redis(redisOptions);
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        this.client!.on('connect', () => {
+          logger.info('Redis client connected');
+          this.isConnected = true;
+          resolve();
+        });
+
+        this.client!.on('error', (err) => {
+          logger.error('Redis client error:', err);
+          if (!this.isConnected) {
+            reject(err);
+          }
+        });
+
+        // Timeout after 5 seconds
+        setTimeout(() => reject(new Error('Redis connection timeout')), 5000);
+      });
+    } catch (error) {
+      if (this.client) {
+        this.client.disconnect();
+        this.client = undefined;
+      }
+      throw error;
+    }
+  }
+
+  getSafeClient(): SafeRedisClient | undefined {
+    if (!this.client || !this.isConnected) {
+      return undefined;
+    }
+
+    // Return a safe subset of Redis commands that won't compromise the system
+    return {
+      get: async (key: string) => {
+        if (!(await this.ensureConnected())) return null;
+        return this.client!.get(key);
+      },
+      set: async (key: string, value: string, expiryMode?: string, time?: number) => {
+        if (!(await this.ensureConnected())) return null;
+        if (expiryMode && time) {
+          return this.client!.set(key, value, expiryMode as any, time);
+        }
+        return this.client!.set(key, value);
+      },
+      del: async (key: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.del(key);
+      },
+      exists: async (key: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.exists(key);
+      },
+      expire: async (key: string, seconds: number) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.expire(key, seconds);
+      },
+      ttl: async (key: string) => {
+        if (!(await this.ensureConnected())) return -2;
+        return this.client!.ttl(key);
+      },
+      incr: async (key: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.incr(key);
+      },
+      decr: async (key: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.decr(key);
+      },
+      incrby: async (key: string, increment: number) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.incrby(key, increment);
+      },
+      decrby: async (key: string, decrement: number) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.decrby(key, decrement);
+      },
+      hget: async (key: string, field: string) => {
+        if (!(await this.ensureConnected())) return null;
+        return this.client!.hget(key, field);
+      },
+      hset: async (key: string, field: string, value: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.hset(key, field, value);
+      },
+      hdel: async (key: string, field: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.hdel(key, field);
+      },
+      hgetall: async (key: string) => {
+        if (!(await this.ensureConnected())) return {};
+        return this.client!.hgetall(key);
+      },
+      hexists: async (key: string, field: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.hexists(key, field);
+      },
+      hkeys: async (key: string) => {
+        if (!(await this.ensureConnected())) return [];
+        return this.client!.hkeys(key);
+      },
+      hvals: async (key: string) => {
+        if (!(await this.ensureConnected())) return [];
+        return this.client!.hvals(key);
+      },
+      hlen: async (key: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.hlen(key);
+      },
+      lpush: async (key: string, ...values: string[]) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.lpush(key, ...values);
+      },
+      rpush: async (key: string, ...values: string[]) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.rpush(key, ...values);
+      },
+      lpop: async (key: string) => {
+        if (!(await this.ensureConnected())) return null;
+        return this.client!.lpop(key);
+      },
+      rpop: async (key: string) => {
+        if (!(await this.ensureConnected())) return null;
+        return this.client!.rpop(key);
+      },
+      llen: async (key: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.llen(key);
+      },
+      lrange: async (key: string, start: number, stop: number) => {
+        if (!(await this.ensureConnected())) return [];
+        return this.client!.lrange(key, start, stop);
+      },
+      sadd: async (key: string, ...members: string[]) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.sadd(key, ...members);
+      },
+      srem: async (key: string, ...members: string[]) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.srem(key, ...members);
+      },
+      sismember: async (key: string, member: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.sismember(key, member);
+      },
+      smembers: async (key: string) => {
+        if (!(await this.ensureConnected())) return [];
+        return this.client!.smembers(key);
+      },
+      scard: async (key: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.scard(key);
+      },
+      zadd: async (key: string, score: number, member: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.zadd(key, score, member);
+      },
+      zrem: async (key: string, member: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.zrem(key, member);
+      },
+      zscore: async (key: string, member: string) => {
+        if (!(await this.ensureConnected())) return null;
+        return this.client!.zscore(key, member);
+      },
+      zrange: async (key: string, start: number, stop: number) => {
+        if (!(await this.ensureConnected())) return [];
+        return this.client!.zrange(key, start, stop);
+      },
+      zrevrange: async (key: string, start: number, stop: number) => {
+        if (!(await this.ensureConnected())) return [];
+        return this.client!.zrevrange(key, start, stop);
+      },
+      zcard: async (key: string) => {
+        if (!(await this.ensureConnected())) return 0;
+        return this.client!.zcard(key);
+      },
+    };
+  }
+
+  async onModuleDestroy() {
+    if (this.client && this.isConnected) {
+      logger.info('Closing Redis connection');
+      await this.client.quit();
+      this.isConnected = false;
+    }
+  }
+} 

--- a/packages/node-core/src/indexer/redis.service.ts
+++ b/packages/node-core/src/indexer/redis.service.ts
@@ -44,6 +44,9 @@ export interface SafeRedisClient {
   zrange: (key: string, start: number, stop: number) => Promise<string[]>;
   zrevrange: (key: string, start: number, stop: number) => Promise<string[]>;
   zcard: (key: string) => Promise<number>;
+  bgsave: () => Promise<string>;
+  lastsave: () => Promise<number>;
+  configGet: (parameter: string) => Promise<string[]>;
 }
 
 @Injectable()
@@ -295,6 +298,18 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
       zcard: async (key: string) => {
         if (!(await this.ensureConnected())) return 0;
         return this.client!.zcard(key);
+      },
+      bgsave: async () => {
+        if (!(await this.ensureConnected())) throw new Error('Redis connection not established');
+        return this.client!.bgsave();
+      },
+      lastsave: async () => {
+        if (!(await this.ensureConnected())) throw new Error('Redis connection not established');
+        return this.client!.lastsave();
+      },
+      configGet: async (parameter: string) => {
+        if (!(await this.ensureConnected())) throw new Error('Redis connection not established');
+        return this.client!.config('GET', parameter) as Promise<string[]>;
       },
     };
   }

--- a/packages/node-core/src/indexer/sandbox.service.ts
+++ b/packages/node-core/src/indexer/sandbox.service.ts
@@ -10,6 +10,7 @@ import {IndexerSandbox} from './sandbox';
 import {StoreService} from './store.service';
 import {ISubqueryProject} from './types';
 import {hostStoreToStore} from './worker';
+import {RedisService} from './redis.service';
 
 /* It would be nice to move this to node core but need to find a way to inject other things into the sandbox */
 @Injectable()
@@ -21,7 +22,8 @@ export class SandboxService<Api, UnsafeApi> {
     private readonly storeService: StoreService,
     private readonly cacheService: InMemoryCacheService,
     private readonly nodeConfig: NodeConfig,
-    @Inject('ISubqueryProject') private readonly project: ISubqueryProject
+    @Inject('ISubqueryProject') private readonly project: ISubqueryProject,
+    private readonly redisService: RedisService
   ) {}
 
   getDsProcessor(
@@ -33,6 +35,7 @@ export class SandboxService<Api, UnsafeApi> {
     const store: Store = isMainThread ? this.storeService.getStore() : hostStoreToStore((global as any).host); // Provided in worker.ts
 
     const cache = this.cacheService.getCache();
+    const redis = this.redisService.getSafeClient();
     const entry = this.getDataSourceEntry(ds);
     let processor = this.processorCache[entry];
     if (!processor) {
@@ -40,6 +43,7 @@ export class SandboxService<Api, UnsafeApi> {
         {
           cache,
           store,
+          redis,
           root: this.project.root,
           entry,
           chainId: this.project.network.chainId,
@@ -48,6 +52,10 @@ export class SandboxService<Api, UnsafeApi> {
       );
       this.processorCache[entry] = processor;
     }
+    
+    // Always update Redis client as it may have connected after sandbox creation
+    processor.freeze(redis, 'redis');
+    
     // Run this before injecting other values so they cannot be overwritten
     for (const [key, value] of Object.entries(extraInjections)) {
       processor.freeze(value, key);

--- a/packages/node-core/src/indexer/sandbox.ts
+++ b/packages/node-core/src/indexer/sandbox.ts
@@ -12,12 +12,14 @@ import {NodeVM, NodeVMOptions, VMError, VMScript} from 'vm2';
 import {NodeConfig} from '../configure/NodeConfig';
 import {getLogger} from '../logger';
 import {timeout} from '../utils/promise';
+import {SafeRedisClient} from './redis.service';
 
 export const SANDBOX_DEFAULT_BUILTINS = ['assert', 'buffer', 'crypto', 'util', 'path', 'url', 'stream'];
 
 export interface SandboxOption {
   cache?: Cache;
   store?: Store;
+  redis?: SafeRedisClient;
   root: string;
   entry: string;
   chainId: string;
@@ -184,13 +186,15 @@ export class IndexerSandbox extends Sandbox {
     }
   }
 
-  private injectGlobals({cache, store}: SandboxOption) {
+  private injectGlobals({cache, store, redis}: SandboxOption) {
     if (store) {
       this.freeze(store, 'store');
     }
     if (cache) {
       this.freeze(cache, 'cache');
     }
+    // Always inject redis, even if undefined
+    this.freeze(redis, 'redis');
     this.freeze(logger, 'logger');
   }
 }

--- a/packages/node-core/src/indexer/worker/worker.core.module.ts
+++ b/packages/node-core/src/indexer/worker/worker.core.module.ts
@@ -9,6 +9,7 @@ import {InMemoryCacheService} from '../inMemoryCache.service';
 import {MonitorService} from '../monitor.service';
 import {SandboxService} from '../sandbox.service';
 import {UnfinalizedBlocksService} from '../unfinalizedBlocks.service';
+import {RedisService} from '../redis.service';
 import {WorkerInMemoryCacheService} from './worker.cache.service';
 import {WorkerConnectionPoolStateManager} from './worker.connectionPoolState.manager';
 import {WorkerDynamicDsService} from './worker.dynamic-ds.service';
@@ -19,6 +20,7 @@ import {WorkerUnfinalizedBlocksService} from './worker.unfinalizedBlocks.service
   providers: [
     ConnectionPoolService,
     SandboxService,
+    RedisService,
     {
       provide: ConnectionPoolStateManager,
       useFactory: () => new WorkerConnectionPoolStateManager((global as any).host),
@@ -47,6 +49,7 @@ import {WorkerUnfinalizedBlocksService} from './worker.unfinalizedBlocks.service
     InMemoryCacheService,
     'IUnfinalizedBlocksService',
     DynamicDsService,
+    RedisService,
   ],
 })
 export class WorkerCoreModule {}

--- a/packages/node/Dockerfile
+++ b/packages/node/Dockerfile
@@ -26,6 +26,7 @@ RUN apk add --no-cache tini curl git redis && \
     tar -xzvf /app.tgz --strip 1 && \
     rm /app.tgz && \
     yarn install --production && \
+    yarn add ioredis && \
     yarn cache clean && \
     rm -rf /root/.npm /root/.cache
 

--- a/packages/types-core/package.json
+++ b/packages/types-core/package.json
@@ -16,6 +16,7 @@
     "/dist"
   ],
   "devDependencies": {
+    "ioredis": "^5.6.1",
     "package-json-type": "^1.0.3"
   }
 }

--- a/packages/types-core/src/global.ts
+++ b/packages/types-core/src/global.ts
@@ -42,6 +42,10 @@ export interface SafeRedisClient {
   zrange: (key: string, start: number, stop: number) => Promise<string[]>;
   zrevrange: (key: string, start: number, stop: number) => Promise<string[]>;
   zcard: (key: string) => Promise<number>;
+  // Persistence methods
+  bgsave: () => Promise<string>;
+  lastsave: () => Promise<number>;
+  configGet: (parameter: string) => Promise<string[]>;
 }
 
 // base global

--- a/packages/types-core/src/global.ts
+++ b/packages/types-core/src/global.ts
@@ -5,11 +5,51 @@ import Pino from 'pino';
 import {Cache, DynamicDatasourceCreator} from './interfaces';
 import {Store} from './store';
 
+// Safe Redis client interface for sandbox usage
+export interface SafeRedisClient {
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string, expiryMode?: string, time?: number) => Promise<string | null>;
+  del: (key: string) => Promise<number>;
+  exists: (key: string) => Promise<number>;
+  expire: (key: string, seconds: number) => Promise<number>;
+  ttl: (key: string) => Promise<number>;
+  incr: (key: string) => Promise<number>;
+  decr: (key: string) => Promise<number>;
+  incrby: (key: string, increment: number) => Promise<number>;
+  decrby: (key: string, decrement: number) => Promise<number>;
+  hget: (key: string, field: string) => Promise<string | null>;
+  hset: (key: string, field: string, value: string) => Promise<number>;
+  hdel: (key: string, field: string) => Promise<number>;
+  hgetall: (key: string) => Promise<Record<string, string>>;
+  hexists: (key: string, field: string) => Promise<number>;
+  hkeys: (key: string) => Promise<string[]>;
+  hvals: (key: string) => Promise<string[]>;
+  hlen: (key: string) => Promise<number>;
+  lpush: (key: string, ...values: string[]) => Promise<number>;
+  rpush: (key: string, ...values: string[]) => Promise<number>;
+  lpop: (key: string) => Promise<string | null>;
+  rpop: (key: string) => Promise<string | null>;
+  llen: (key: string) => Promise<number>;
+  lrange: (key: string, start: number, stop: number) => Promise<string[]>;
+  sadd: (key: string, ...members: string[]) => Promise<number>;
+  srem: (key: string, ...members: string[]) => Promise<number>;
+  sismember: (key: string, member: string) => Promise<number>;
+  smembers: (key: string) => Promise<string[]>;
+  scard: (key: string) => Promise<number>;
+  zadd: (key: string, score: number, member: string) => Promise<number>;
+  zrem: (key: string, member: string) => Promise<number>;
+  zscore: (key: string, member: string) => Promise<string | null>;
+  zrange: (key: string, start: number, stop: number) => Promise<string[]>;
+  zrevrange: (key: string, start: number, stop: number) => Promise<string[]>;
+  zcard: (key: string) => Promise<number>;
+}
+
 // base global
 declare global {
   const logger: Pino.Logger;
   const store: Store;
   const cache: Cache;
+  const redis: SafeRedisClient | undefined;
   const chainId: string;
   const createDynamicDatasource: DynamicDatasourceCreator;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4656,6 +4656,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ioredis/commands@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "@ioredis/commands@npm:1.2.0"
+  checksum: 9b20225ba36ef3e5caf69b3c0720597c3016cc9b1e157f519ea388f621dd9037177f84cfe7e25c4c32dad7dd90c70ff9123cd411f747e053cf292193c9c461e2
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -7976,6 +7983,7 @@ __metadata:
     cross-fetch: ^3.1.6
     csv-stringify: ^6.5.1
     dayjs: ^1.11.12
+    ioredis: ^5.6.1
     lodash: ^4.17.21
     lru-cache: 10.1.0
     merkle-tools: ^1.4.1
@@ -8102,6 +8110,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@subql/types-core@workspace:packages/types-core"
   dependencies:
+    ioredis: ^5.6.1
     package-json-type: ^1.0.3
   languageName: unknown
   linkType: soft
@@ -11922,6 +11931,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cluster-key-slot@npm:^1.1.0":
+  version: 1.1.2
+  resolution: "cluster-key-slot@npm:1.1.2"
+  checksum: be0ad2d262502adc998597e83f9ded1b80f827f0452127c5a37b22dfca36bab8edf393f7b25bb626006fb9fb2436106939ede6d2d6ecf4229b96a47f27edd681
+  languageName: node
+  linkType: hard
+
 "cmd-shim@npm:^5.0.0":
   version: 5.0.0
   resolution: "cmd-shim@npm:5.0.0"
@@ -12693,6 +12709,13 @@ __metadata:
   version: 1.0.0
   resolution: "delegates@npm:1.0.0"
   checksum: a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
+  languageName: node
+  linkType: hard
+
+"denque@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "denque@npm:2.1.0"
+  checksum: 1d4ae1d05e59ac3a3481e7b478293f4b4c813819342273f3d5b826c7ffa9753c520919ba264f377e09108d24ec6cf0ec0ac729a5686cbb8f32d797126c5dae74
   languageName: node
   linkType: hard
 
@@ -15876,6 +15899,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ioredis@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "ioredis@npm:5.6.1"
+  dependencies:
+    "@ioredis/commands": ^1.1.1
+    cluster-key-slot: ^1.1.0
+    debug: ^4.3.4
+    denque: ^2.1.0
+    lodash.defaults: ^4.2.0
+    lodash.isarguments: ^3.1.0
+    redis-errors: ^1.2.0
+    redis-parser: ^3.0.0
+    standard-as-callback: ^2.1.0
+  checksum: 89100a97b2210fed2aca45daf902adee8aa2294e56f817742651c86234a3efa56f82aa5aa762a94f5fbf806942f259ef5e628f626d1841d20d5cbb163fc8bd3f
+  languageName: node
+  linkType: hard
+
 "ip@npm:^1.1.5":
   version: 1.1.9
   resolution: "ip@npm:1.1.9"
@@ -17615,10 +17655,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.defaults@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lodash.defaults@npm:4.2.0"
+  checksum: 84923258235592c8886e29de5491946ff8c2ae5c82a7ac5cddd2e3cb697e6fbdfbbb6efcca015795c86eec2bb953a5a2ee4016e3735a3f02720428a40efbb8f1
+  languageName: node
+  linkType: hard
+
 "lodash.get@npm:^4.4.2":
   version: 4.4.2
   resolution: "lodash.get@npm:4.4.2"
   checksum: e403047ddb03181c9d0e92df9556570e2b67e0f0a930fcbbbd779370972368f5568e914f913e93f3b08f6d492abc71e14d4e9b7a18916c31fa04bd2306efe545
+  languageName: node
+  linkType: hard
+
+"lodash.isarguments@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "lodash.isarguments@npm:3.1.0"
+  checksum: ae1526f3eb5c61c77944b101b1f655f846ecbedcb9e6b073526eba6890dc0f13f09f72e11ffbf6540b602caee319af9ac363d6cdd6be41f4ee453436f04f13b5
   languageName: node
   linkType: hard
 
@@ -21023,6 +21077,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redis-errors@npm:^1.0.0, redis-errors@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "redis-errors@npm:1.2.0"
+  checksum: f28ac2692113f6f9c222670735aa58aeae413464fd58ccf3fce3f700cae7262606300840c802c64f2b53f19f65993da24dc918afc277e9e33ac1ff09edb394f4
+  languageName: node
+  linkType: hard
+
+"redis-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redis-parser@npm:3.0.0"
+  dependencies:
+    redis-errors: ^1.0.0
+  checksum: 89290ae530332f2ae37577647fa18208d10308a1a6ba750b9d9a093e7398f5e5253f19855b64c98757f7129cccce958e4af2573fdc33bad41405f87f1943459a
+  languageName: node
+  linkType: hard
+
 "reduce-flatten@npm:^2.0.0":
   version: 2.0.0
   resolution: "reduce-flatten@npm:2.0.0"
@@ -22303,6 +22373,13 @@ __metadata:
   dependencies:
     escape-string-regexp: ^2.0.0
   checksum: 76b69da0f5b48a34a0f93c98ee2a96544d2c4ca2557f7eef5ddb961d3bdc33870b46f498a84a7c4f4ffb781df639840e7ebf6639164ed4da5e1aeb659615b9c7
+  languageName: node
+  linkType: hard
+
+"standard-as-callback@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "standard-as-callback@npm:2.1.0"
+  checksum: 88bec83ee220687c72d94fd86a98d5272c91d37ec64b66d830dbc0d79b62bfa6e47f53b71646011835fc9ce7fae62739545d13124262b53be4fbb3e2ebad551c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR introduces Redis support to SubQuery's indexer, allowing mapping handlers to use Redis as an external cache/data store. The implementation includes both basic Redis functionality and persistence features to ensure data recovery after unexpected shutdowns.

## Motivation

Currently, when trying to use Redis in SubQuery mapping files, users encounter file descriptor errors and have to resort to subprocess commands, which is inefficient and error-prone. This PR provides native Redis support as a global variable in the sandbox environment, similar to how `store` and `cache` are provided.

## Changes

### Core Implementation (0529f366b7)

1. **New Redis Service** (`packages/node-core/src/indexer/redis.service.ts`)
   - Created `RedisService` class with `SafeRedisClient` interface
   - Supports multiple connection methods:
     - Environment variables: `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB`
     - Connection string: `REDIS_ENDPOINT`
   - Implements lazy connection with retry strategy
   - Provides safe subset of Redis commands for sandbox usage

2. **Sandbox Integration**
   - Modified `packages/node-core/src/indexer/sandbox.ts` to accept redis in `SandboxOption`
   - Updated `IndexerSandbox.injectGlobals()` to always inject redis (even if undefined)
   - Modified `packages/node-core/src/indexer/sandbox.service.ts` to inject Redis client

3. **Module Configuration**
   - Added `RedisService` to `CoreModule` and `WorkerCoreModule` providers/exports
   - Added `ioredis` dependency to node-core and types-core packages

4. **Docker Support**
   - Updated `packages/node/Dockerfile` to install ioredis package

5. **Type Definitions**
   - Added `SafeRedisClient` interface to `packages/types-core/src/global.ts`
   - Declared global `redis` variable for TypeScript support

### Persistence Features (02fbe8de8e)

1. **Additional Redis Commands**
   - `bgsave()` - Triggers background save to disk (non-blocking)
   - `lastsave()` - Returns Unix timestamp of last successful save
   - `configGet(parameter)` - Gets Redis configuration values

2. **Type Updates**
   - Extended `SafeRedisClient` interface with persistence methods

## Safe Redis Commands

The implementation provides a safe subset of Redis commands that won't compromise system security:

### Basic Operations
- `get`, `set`, `del`, `exists`, `expire`, `ttl`
- `incr`, `decr`, `incrby`, `decrby`

### Hash Operations
- `hget`, `hset`, `hdel`, `hgetall`
- `hexists`, `hkeys`, `hvals`, `hlen`

### List Operations
- `lpush`, `rpush`, `lpop`, `rpop`
- `llen`, `lrange`

### Set Operations
- `sadd`, `srem`, `sismember`
- `smembers`, `scard`

### Sorted Set Operations
- `zadd`, `zrem`, `zscore`
- `zrange`, `zrevrange`, `zcard`

### Persistence Operations
- `bgsave`, `lastsave`, `configGet`

## Usage Example

```typescript
// In your mapping handler
export async function handleBlock(block: SubstrateBlock): Promise<void> {
  // Basic usage
  await redis.set(`block:${block.number}`, JSON.stringify(block.header));
  
  // Check persistence
  const lastSave = await redis.lastsave();
  logger.info(`Last Redis save: ${new Date(lastSave * 1000).toISOString()}`);
  
  // Trigger save every 100 blocks
  if (block.number % 100 === 0) {
    await redis.bgsave();
  }
}
```

## Configuration

### Environment Variables
```bash
# Basic configuration
REDIS_HOST=localhost
REDIS_PORT=6379
REDIS_DB=0
REDIS_PASSWORD=your_password

# Or use connection string
REDIS_ENDPOINT=redis://localhost:6379/0
```

### Docker Compose with Persistence
```yaml
services:
  redis:
    image: redis:7-alpine
    command: redis-server --save 60 1000 --loglevel warning --appendonly yes
    volumes:
      - redis-data:/data
    ports:
      - "6379:6379"
```

## Key Design Decisions

1. **Security**: Redis runs outside the sandbox with only safe commands exposed
2. **Graceful Degradation**: Redis is optional - indexing continues if Redis is unavailable
3. **Lazy Connection**: Redis connects on first use or during module initialization
4. **Auto-reconnection**: Built-in retry strategy for connection failures
5. **Worker Support**: Redis service is available in both main thread and worker threads