### PR TITLE
Enhance blockchain service to handle genesis block missing timestamp

### DIFF
--- a/packages/node/src/blockchain.service.ts
+++ b/packages/node/src/blockchain.service.ts
@@ -9,6 +9,7 @@ import {
   IBlock,
   IBlockchainService,
   mainThreadOnly,
+  getLogger,
 } from '@subql/node-core';
 import {
   SubstrateCustomDatasource,
@@ -38,6 +39,7 @@ import {
   getHeaderForHash,
 } from './utils/substrate';
 
+const logger = getLogger('BlockchainService');
 const BLOCK_TIME_VARIANCE = 5000; //ms
 const INTERVAL_PERCENT = 0.9;
 
@@ -116,6 +118,12 @@ export class BlockchainService
   }
 
   async getBlockTimestamp(height: number): Promise<Date> {
+    // Special handling for genesis block
+    if (height === 0) {
+      logger.debug('Using Unix epoch timestamp for genesis block');
+      return new Date(0);
+    }
+
     const block = await getBlockByHeight(this.apiService.api, height);
 
     let timestamp = getTimestamp(block);

--- a/packages/node/src/utils/substrate.ts
+++ b/packages/node/src/utils/substrate.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import assert from 'assert';
 import { ApiPromise } from '@polkadot/api';
 import '@polkadot/api-augment/substrate';
 import { Bytes, Option, Vec } from '@polkadot/types';
@@ -28,7 +29,6 @@ import {
   SubstrateEventFilter,
   SubstrateExtrinsic,
 } from '@subql/types';
-import assert from 'assert';
 import { merge } from 'lodash';
 import { SubqlProjectBlockFilter } from '../configure/SubqueryProject';
 import { ApiPromiseConnection } from '../indexer/apiPromise.connection';
@@ -75,8 +75,12 @@ export function wrapBlock(
 }
 
 export function getTimestamp({
-  block: { extrinsics },
+  block: { extrinsics, header },
 }: SignedBlock): Date | undefined {
+  // Genesis block (block 0) typically doesn't have timestamp extrinsics
+  if (header.number.toNumber() === 0) {
+    return new Date(0);
+  }
   // extrinsics can be undefined when fetching light blocks
   if (extrinsics) {
     for (const e of extrinsics) {
@@ -121,7 +125,6 @@ export function wrapExtrinsics(
   const currentBlockNumber = wrappedBlock.block.header.number.toNumber();
   // console.log(`[DEBUG] wrapExtrinsics: Processing block: ${currentBlockNumber}`);
   // console.log(`[DEBUG] wrapExtrinsics: Received allEvents.length: ${allEvents.length}`);
-
 
   const groupedEvents = groupEventsByExtrinsic(allEvents);
   return wrappedBlock.block.extrinsics.map((extrinsic, idx) => {
@@ -379,8 +382,10 @@ export async function fetchEventsRange(
   return Promise.all(
     hashs.map(async (hash) => {
       try {
-        const blockNumber = (await api.rpc.chain.getHeader(hash)).number.toNumber();
-        
+        const blockNumber = (
+          await api.rpc.chain.getHeader(hash)
+        ).number.toNumber();
+
         // Try the standard events query
         try {
           const events = await api.query.system.events.at(hash);
@@ -391,71 +396,94 @@ export async function fetchEventsRange(
         } catch (standardErr) {
           // console.log(`[DEBUG] Block ${blockNumber}: Standard events query failed, trying segmented approach`);
         }
-        
+
         // Fall back to segmented events approach
-        let eventsForBlock: Vec<EventRecord> = api.registry.createType('Vec<EventRecord>');
+        let eventsForBlock: Vec<EventRecord> =
+          api.registry.createType('Vec<EventRecord>');
         let allEvents: EventRecord[] = [];
-        
+
         try {
           // Get total event count for this block
           const totalEventCount = await api.query.system.eventCount.at(hash);
           // @ts-ignore - Handle potential Codec type
-          const eventCount = totalEventCount && totalEventCount.toNumber ? totalEventCount.toNumber() : 0;
-          
+          const eventCount =
+            totalEventCount && totalEventCount.toNumber
+              ? totalEventCount.toNumber()
+              : 0;
+
           if (eventCount > 0) {
             // console.log(`[DEBUG] Block ${blockNumber} has ${eventCount} events (using segmented approach)`);
-            
+
             // Calculate number of segments to check (EventSegmentSize = 100)
             const SEGMENT_SIZE = 100;
             const numSegments = Math.ceil(eventCount / SEGMENT_SIZE);
-            
+
             // Fetch events from all segments
-            for (let segmentIndex = 0; segmentIndex < numSegments; segmentIndex++) {
-              const segmentData = await api.query.system.eventSegments.at(hash, segmentIndex);
-              
+            for (
+              let segmentIndex = 0;
+              segmentIndex < numSegments;
+              segmentIndex++
+            ) {
+              const segmentData = await api.query.system.eventSegments.at(
+                hash,
+                segmentIndex,
+              );
+
               if (!segmentData) continue;
-              
+
               let eventsInSegment: EventRecord[] = [];
-              
+
               // Handle potential Option wrapping
               // @ts-ignore - Types are handled at runtime
-              if (segmentData.isSome !== undefined && typeof segmentData.unwrap === 'function') {
+              if (
+                segmentData.isSome !== undefined &&
+                typeof segmentData.unwrap === 'function'
+              ) {
                 // @ts-ignore
                 if (segmentData.isNone) continue;
                 // @ts-ignore
                 const unwrapped = segmentData.unwrap();
                 // @ts-ignore
                 eventsInSegment = unwrapped.toArray ? unwrapped.toArray() : [];
-              } 
+              }
               // @ts-ignore
               else if (segmentData.toArray !== undefined) {
                 // @ts-ignore
                 eventsInSegment = segmentData.toArray();
               }
-              
+
               if (eventsInSegment.length > 0) {
                 // console.log(`[DEBUG] Found ${eventsInSegment.length} events in segment ${segmentIndex}`);
                 allEvents = allEvents.concat(eventsInSegment);
               }
             }
-            
+
             if (allEvents.length > 0) {
               // console.log(`[DEBUG] Total events collected: ${allEvents.length} (expected ${eventCount})`);
-              eventsForBlock = api.registry.createType('Vec<EventRecord>', allEvents);
+              eventsForBlock = api.registry.createType(
+                'Vec<EventRecord>',
+                allEvents,
+              );
             }
           }
         } catch (err) {
           // Both approaches failed, log warning
-          logger.warn(`Failed to fetch events for block ${blockNumber} using both standard and segmented approaches`);
+          logger.warn(
+            `Failed to fetch events for block ${blockNumber} using both standard and segmented approaches`,
+          );
         }
-        
+
         return eventsForBlock;
       } catch (e: any) {
         let blockNumForError = 'unknown';
-        try { 
-          blockNumForError = (await api.rpc.chain.getHeader(hash)).number.toString(); 
-        } catch (_) {}
-        
+        try {
+          blockNumForError = (
+            await api.rpc.chain.getHeader(hash)
+          ).number.toString();
+        } catch (_) {
+          // Intentionally empty - we'll use 'unknown' as the block number in the error message
+        }
+
         logger.error(
           `failed to fetch events at block ${hash} (Number: ${blockNumForError})${getApiDecodeErrMsg(
             e.message,


### PR DESCRIPTION
This pull request introduces improvements to the handling of genesis blocks missing timestamps. Prior to this if the node finalized block returned block 0 the node would crash with an "Timestamp is not reliable" error.

### Genesis Block Handling and Logging:

* [`packages/node/src/blockchain.service.ts`](diffhunk://#diff-072c443b10d14f52c1d7ce0f043f867a7bd72751d284d763fe13ee80b4a4db5cR121-R126): Added special handling for the genesis block in the `getBlockTimestamp` method, using the Unix epoch timestamp and logging a debug message.
* [`packages/node/src/blockchain.service.ts`](diffhunk://#diff-072c443b10d14f52c1d7ce0f043f867a7bd72751d284d763fe13ee80b4a4db5cR42): Introduced a logger instance (`logger`) for the `BlockchainService` class to facilitate debugging.

* [`packages/node/src/utils/substrate.ts`](diffhunk://#diff-622aec34f349237d6d2b7b613e44aedbe25468c88ba6597f2051bb9c825d55f4L78-R83): Enhanced the `getTimestamp` function to return the Unix epoch timestamp for genesis blocks, which typically lack timestamp extrinsics.
